### PR TITLE
fix failure at pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,5 @@ jobs:
       run: mypy --ignore-missing-imports .
     - name: Test with pytest
       run: |
+        pip install -e .
         pytest tests


### PR DESCRIPTION
# Summary

`pytest` fails since this repository is not installed.  
So, I have added installing this with pip `ci.yml` to fix the bug.

# Changes

- Add `pip install` to test with pytest