### PR TITLE
create Uploader class and moved to that of Photo class

### DIFF
--- a/photo_backup/photo.py
+++ b/photo_backup/photo.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
-import boto3
 from PIL import Image
 
-import photo_backup.consts as consts
 from photo_backup.exif import extract_exif
 
 
@@ -23,13 +21,3 @@ class Photo(object):
         filename = datetime_original.strftime("%Y%m%d%H%M%S")
         extension = self.extract_file_extension()
         return f"{year}/{month}/{filename}{extension}"
-
-    def upload(self):
-        s3 = boto3.client("s3")
-        src_path = str(self.path)
-        dst_path = self.create_dst_path()
-        s3.upload_file(
-            src_path,
-            consts.S3_BUCKET,
-            dst_path,
-        )

--- a/photo_backup/upload.py
+++ b/photo_backup/upload.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+import boto3
+
+from photo_backup.photo import Photo
+
+
+class Uploader(ABC):
+    @abstractmethod
+    def upload(self, photo: Photo):
+        pass
+
+
+class S3Uploader(Uploader):
+    def __init__(self, bucket: str):
+        self.bucket = bucket
+
+    def upload(self, photo: Photo):
+        s3 = boto3.client("s3")
+        src_path = str(photo.path)
+        dst_path = photo.create_dst_path()
+        s3.upload_file(
+            src_path,
+            self.bucket,
+            dst_path,
+        )

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from photo_backup.photo import Photo
 from PIL import Image
+
+from photo_backup.photo import Photo
 
 
 class TestPhotoInit:

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,12 +1,9 @@
 from datetime import datetime
 from pathlib import Path
 
-import boto3
 import pytest
-from PIL import Image
-
-import photo_backup.consts as consts
 from photo_backup.photo import Photo
+from PIL import Image
 
 
 class TestPhotoInit:
@@ -45,19 +42,3 @@ class TestPhotoCreateDstPath:
         actual = Photo("data/images/IMG_9235.jpeg").create_dst_path()
         expected = "2020/08/20200813140708.jpeg"
         assert actual == expected
-
-
-class TestPhotoUploadToS3:
-    def test_upload(self):
-        Photo("data/images/IMG_9235.jpeg").upload()
-
-        s3 = boto3.client("s3")
-        response = s3.list_objects_v2(
-            Bucket=consts.S3_BUCKET, Prefix="2020/08"
-        )
-        uploaded_filename = response["Contents"][0]["Key"]
-        expected = "2020/08/20200813140708.jpeg"
-
-        assert uploaded_filename == expected
-
-        s3.delete_object(Bucket=consts.S3_BUCKET, Key=expected)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,22 @@
+import boto3
+import photo_backup.consts as consts
+from photo_backup.photo import Photo
+from photo_backup.upload import S3Uploader
+
+
+class TestS3UploaderUpload:
+    def test_upload(self):
+        photo = Photo("data/images/IMG_9235.jpeg")
+        uploader = S3Uploader(consts.S3_BUCKET)
+        uploader.upload(photo)
+
+        s3 = boto3.client("s3")
+        response = s3.list_objects_v2(
+            Bucket=consts.S3_BUCKET, Prefix="2020/08"
+        )
+        uploaded_filename = response["Contents"][0]["Key"]
+        expected = "2020/08/20200813140708.jpeg"
+
+        assert uploaded_filename == expected
+
+        s3.delete_object(Bucket=consts.S3_BUCKET, Key=expected)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,4 +1,5 @@
 import boto3
+
 import photo_backup.consts as consts
 from photo_backup.photo import Photo
 from photo_backup.upload import S3Uploader


### PR DESCRIPTION
# Summary

To easily change upload method, I decided to split it from Photo class.  

# Changes

- Deleted upload method of Photo class and related import statements.
- Deleted a unittest for upload method of Photo class and related import statments.
- Created `upload.py`.
- Created `test_upload.py`, which tests the Uploader class.