### PR TITLE
black's line length was set 79

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 21.5b0
     hooks:
         - id: black
+          args: [--line-length, "79"]
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.8.0


### PR DESCRIPTION
# Summary

The line length in Black, a code formatter, was set 79 in pre-commit.

# Changes

- Added args `--line-length 79` to black