### PR TITLE
Add photo collection class

### DIFF
--- a/photo_backup/photo.py
+++ b/photo_backup/photo.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from typing import List
 
 from PIL import Image
 
 from photo_backup.exif import extract_exif
+from photo_backup.upload import Uploader
 
 
 class Photo(object):
@@ -21,3 +23,19 @@ class Photo(object):
         filename = datetime_original.strftime("%Y%m%d%H%M%S")
         extension = self.extract_file_extension()
         return f"{year}/{month}/{filename}{extension}"
+
+
+class Photos(object):
+    def __init__(self, uploader: Uploader):
+        self.uploader = uploader
+        self.photos: List[Photo] = []
+
+    def append(self, photo: Photo):
+        self.photos.append(photo)
+        return self
+
+    def upload(self):
+        for photo in self.photos:
+            src = photo.path
+            dst = photo.create_dst_path()
+            self.uploader.upload(src, dst)

--- a/photo_backup/upload.py
+++ b/photo_backup/upload.py
@@ -1,13 +1,14 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 import boto3
 
-from photo_backup.photo import Photo
+S3Uri = str
 
 
 class Uploader(ABC):
     @abstractmethod
-    def upload(self, photo: Photo):
+    def upload(self, src: Path, dst: S3Uri):
         pass
 
 
@@ -15,12 +16,10 @@ class S3Uploader(Uploader):
     def __init__(self, bucket: str):
         self.bucket = bucket
 
-    def upload(self, photo: Photo):
+    def upload(self, src: Path, dst: S3Uri):
         s3 = boto3.client("s3")
-        src_path = str(photo.path)
-        dst_path = photo.create_dst_path()
         s3.upload_file(
-            src_path,
+            str(src),
             self.bucket,
-            dst_path,
+            dst,
         )

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,10 +1,14 @@
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
+import boto3
 import pytest
 from PIL import Image
 
-from photo_backup.photo import Photo
+import photo_backup.consts as consts
+from photo_backup.photo import Photo, Photos
+from photo_backup.upload import S3Uploader
 
 
 class TestPhotoInit:
@@ -43,3 +47,77 @@ class TestPhotoCreateDstPath:
         actual = Photo("data/images/IMG_9235.jpeg").create_dst_path()
         expected = "2020/08/20200813140708.jpeg"
         assert actual == expected
+
+
+class TestPhotosInit:
+    def test_init_uploader(self):
+        expected = S3Uploader(consts.S3_BUCKET)
+        photos = Photos(expected)
+        actual = photos.uploader
+        assert actual == expected
+
+    def test_init_photos(self):
+        photos = Photos(S3Uploader(consts.S3_BUCKET))
+        actual = photos.photos
+        expected = []
+        assert actual == expected
+
+
+class TestPhotosAppend:
+    def test_photos_attribute(self):
+        photos = Photos(S3Uploader(consts.S3_BUCKET))
+
+        photo1 = Photo("data/images/IMG_9235.jpeg")
+        photos.append(photo1)
+
+        photo2 = Photo("data/images/SOVK6553.jpeg")
+        photos.append(photo2)
+
+        expected = [photo1, photo2]
+        actual = photos.photos
+
+        assert actual == expected
+
+    def test_return_object(self):
+        photos = Photos(S3Uploader(consts.S3_BUCKET))
+
+        photo1 = Photo("data/images/IMG_9235.jpeg")
+        actual = photos.append(photo1)
+        expected = photos
+        assert actual == expected
+
+
+class TestPhotosUpload:
+    def test_upload(self):
+        photos = Photos(S3Uploader(consts.S3_BUCKET))
+
+        photo1 = Photo("data/images/IMG_9235.jpeg")
+        photos.append(photo1)
+
+        photo2 = Photo("data/images/SOVK6553.jpeg")
+        photos.append(photo2)
+
+        photos.upload()
+
+        s3 = boto3.client("s3")
+        response = s3.list_objects_v2(Bucket=consts.S3_BUCKET, Prefix="2020")
+        uploaded_filename = [
+            content["Key"] for content in response["Contents"]
+        ]
+        expected = [
+            "2020/08/20200813140708.jpeg",
+            "2020/10/20201012131028.jpeg",
+        ]
+
+        assert uploaded_filename == expected
+
+        response = subprocess.run(
+            [
+                "aws",
+                "s3",
+                "rm",
+                "--recursive",
+                f"s3://{consts.S3_BUCKET}/2020/",
+            ]
+        )
+        response.check_returncode()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,22 +1,21 @@
 import boto3
 
 import photo_backup.consts as consts
-from photo_backup.photo import Photo
 from photo_backup.upload import S3Uploader
 
 
 class TestS3UploaderUpload:
     def test_upload(self):
-        photo = Photo("data/images/IMG_9235.jpeg")
+        expected = "2020/08/20200813140708.jpeg"
+
         uploader = S3Uploader(consts.S3_BUCKET)
-        uploader.upload(photo)
+        uploader.upload("data/images/IMG_9235.jpeg", expected)
 
         s3 = boto3.client("s3")
         response = s3.list_objects_v2(
             Bucket=consts.S3_BUCKET, Prefix="2020/08"
         )
         uploaded_filename = response["Contents"][0]["Key"]
-        expected = "2020/08/20200813140708.jpeg"
 
         assert uploaded_filename == expected
 


### PR DESCRIPTION
# Summary

`Photos` class, the collection class of `Photo`, holds `Photo` instances and will be used to upload that instances.

# Changes

- `Photos` class was added to photo.py
- the unit tests of `Photos` was added to test_photo.py
- `upload.py` was refactored to resolve circular reference between `Uploader` and `Photo`
- `test_upload.py` was also refactored because of above