### PR TITLE
fix #14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
         pip install -e .
         cd tests
         pytest -v .
+    - name: Debug
+      if: ${{ always() }}
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         pip install -e .
         cd tests
-        pytest .
+        pytest -v .

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pycodestyle==2.7.0
 pyflakes==2.3.1
 pyparsing==2.4.7
 pytest==6.1.2
+pytest-mock==3.6.1
 python-dateutil==2.8.1
 PyYAML==5.4.1
 regex==2021.4.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def folder_test():
+    return "test/python-{}.{}".format(*sys.version_info[:2])

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -5,15 +5,15 @@ from photo_backup.upload import S3Uploader
 
 
 class TestS3UploaderUpload:
-    def test_upload(self):
-        expected = "2020/08/20200813140708.jpeg"
+    def test_upload(self, folder_test):
+        expected = f"{folder_test}/2020/08/20200813140708.jpeg"
 
         uploader = S3Uploader(consts.S3_BUCKET)
         uploader.upload("data/images/IMG_9235.jpeg", expected)
 
         s3 = boto3.client("s3")
         response = s3.list_objects_v2(
-            Bucket=consts.S3_BUCKET, Prefix="2020/08"
+            Bucket=consts.S3_BUCKET, Prefix=f"{folder_test}/2020/08"
         )
         uploaded_filename = response["Contents"][0]["Key"]
 


### PR DESCRIPTION
# Summary

This PR have fixed #14.

# Changes

- `pytest-mock` was installed with pip
- `conftest.py` was created since I want to use a fixture between test files.
- `TestPhotosUpload.test_upload` in `test_photo.py` was changed for that uploading files put different folders by Python version.
- `TestS3UploaderUpload.test_upload` in `test_upload.py` was also changed by same reason above.