### PR TITLE
Saving the memory, Photo.photo was deleted

### DIFF
--- a/photo_backup/photo.py
+++ b/photo_backup/photo.py
@@ -10,8 +10,7 @@ from .upload import Uploader
 class Photo(object):
     def __init__(self, path: str):
         self.path = Path(path)
-        self.photo = Image.open(path)
-        self.exif = extract_exif(self.photo)
+        self.exif = extract_exif(Image.open(path))
 
     def extract_file_extension(self) -> str:
         return self.path.suffix

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import boto3
 import pytest
-from PIL import Image
 
 import photo_backup.consts as consts
 from photo_backup.photo import Photo, Photos
@@ -23,11 +22,6 @@ class TestPhotoInit:
         _path, _photo = photo
         expected = Path(_path)
         assert _photo.path == expected
-
-    def test_init_photo(self, photo):
-        _path, _photo = photo
-        expected = Image.open(_path)
-        assert _photo.photo == expected
 
     def test_init_exif(self, photo):
         _path, _photo = photo


### PR DESCRIPTION
# Summary

I want to upload thousands of photos in a time, so I have deleted  the photo attribute in Photo to save the memory.

# Changes

- photo attribute in Photo was deleted
- a unittest for `photo` was deleted